### PR TITLE
ci: add WordPress Playground PR previewer

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,62 @@
+name: Playground PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Playground URL
+        id: url
+        env:
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          BLUEPRINT=$(jq -nc \
+            --arg repo "$PR_REPO" \
+            --arg branch "$PR_BRANCH" \
+            --arg sha "$PR_SHA" \
+            '{
+              "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+              "preferredVersions": {"php": "8.3", "wp": "7.0"},
+              "landingPage": "/wp-admin/index.php",
+              "login": true,
+              "steps": [
+                {
+                  "step": "installPlugin",
+                  "pluginData": {
+                    "resource": "url",
+                    "url": ("https://github-proxy.com/proxy/?repo=" + $repo + "&branch=" + $branch)
+                  }
+                },
+                {
+                  "step": "runPHP",
+                  "code": "<?php require_once '/wordpress/wp-load.php'; $now = time(); $samples = [['Half-finished essay on remote work', 600, 90], ['Quick thought from last week', 80, 5], ['Long-abandoned tutorial', 1200, 540], ['', 30, 2], ['Almost-ready announcement', 700, 30], ['Old draft from years ago', 200, 900]]; global $wpdb; foreach ($samples as [$title, $words, $age]) { $content = str_repeat('Lorem ipsum dolor sit amet. ', max(1, (int)($words/4))); $id = wp_insert_post(['post_title'=>$title,'post_content'=>$content,'post_status'=>'draft','post_author'=>1]); $when = gmdate('Y-m-d H:i:s', $now - $age*DAY_IN_SECONDS); $local = get_date_from_gmt($when); $wpdb->update($wpdb->posts, ['post_date'=>$local,'post_date_gmt'=>$when,'post_modified'=>$local,'post_modified_gmt'=>$when], ['ID'=>$id]); clean_post_cache($id); }"
+                }
+              ]
+            }')
+          ENCODED=$(jq -rn --arg j "$BLUEPRINT" '$j|@uri')
+          echo "url=https://playground.wordpress.net/?blueprint=${ENCODED}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(echo "$PR_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Sticky preview comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: playground-preview
+          message: |
+            ### Playground PR Preview
+
+            Try this PR live in your browser — no setup required:
+
+            **[Open in WordPress Playground →](${{ steps.url.outputs.url }})**
+
+            Boots WP 7.0 on PHP 8.3 with this branch's code installed, activated, and seeded with six demo drafts. Logs you in as admin so the dashboard widget renders immediately.
+
+            <sub>Built from `${{ steps.url.outputs.sha_short }}` · Updates automatically on each push.</sub>

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,12 @@
+{
+	"core": "https://wordpress.org/wordpress-7.0-RC2.zip",
+	"phpVersion": "8.2",
+	"plugins": ["."],
+	"port": 8890,
+	"testsPort": 8891,
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_MEMORY_LIMIT": "256M"
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/playground-preview.yml` that runs on every PR open/sync/reopen
- Posts a sticky comment with a one-click [WordPress Playground](https://wordpress.github.io/wordpress-playground/) link booting WP 7.0 + PHP 8.3 with the PR's code installed
- Blueprint also seeds six demo drafts (varying age/length, including one untitled) and auto-logs-in, so the dashboard widget renders fully on first load

This PR is the first test of the workflow — once merged to `main`, the next PR will get a Playground link in its first comment.

## Test plan

- [ ] Workflow runs and a sticky comment appears on this PR
- [ ] Click the link and confirm Playground boots, plugin is active, drafts are seeded, dashboard widget renders top 3 with reason badges
- [ ] Push another commit and confirm the comment updates (new short SHA in the footer) instead of stacking