### PR TITLE
Design pass, only show one draft at a time

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -1,43 +1,37 @@
-/* Draft Sweeper widget — uses WordPress admin design tokens. */
+/* Draft Sweeper widget — a small bookplate for the day's draft. */
 #draft_sweeper_widget .inside { margin: 0; padding: 0; }
 
 .ds-widget {
   --ds-text: #1d2327;
   --ds-text-secondary: #50575e;
   --ds-text-soft: #787c82;
-  --ds-border: #dcdcde;
-  --ds-surface-alt: #f6f7f7;
+  --ds-paper: #f6f7f7;
   --ds-accent: var(--wp-admin-theme-color, #2271b1);
   color: var(--ds-text);
   font-size: 13px;
   line-height: 1.5;
+  background: var(--ds-paper);
 }
 
 .ds-list { margin: 0; padding: 0; list-style: none; }
+
 .ds-item {
-  padding: 16px 14px;
-  border-bottom: 1px solid var(--ds-border);
+  margin: 0;
+  padding: 24px 22px;
 }
-.ds-item:last-child { border-bottom: 0; }
+.ds-item.is-dismissing { opacity: 0.4; transition: opacity 0.2s; }
 
 .ds-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  background: rgba(80, 87, 94, 0.08);
+  display: block;
+  margin-bottom: 14px;
+  font-size: 13px;
   color: var(--ds-text-secondary);
-  margin-bottom: 10px;
 }
 
 .ds-teaser {
-  margin: 0 0 8px;
+  margin: 0 0 14px;
   font-family: Georgia, "Times New Roman", serif;
-  font-style: italic;
-  font-size: 15px;
+  font-size: 18px;
   line-height: 1.45;
   color: var(--ds-text);
 }
@@ -53,49 +47,36 @@
 .ds-title:hover { color: var(--ds-accent); text-decoration: underline; }
 .ds-untitled { font-style: italic; color: var(--ds-text-soft); }
 
-.ds-meta {
-  margin: 4px 0 12px;
-  color: var(--ds-text-soft);
-  font-size: 12px;
-}
-.ds-meta-sep { margin: 0 6px; opacity: 0.6; }
-
-.ds-actions { display: flex; gap: 6px; }
-
-.ds-footer {
-  padding: 12px 14px;
-  background: var(--ds-surface-alt);
-  border-top: 1px solid var(--ds-border);
-  text-align: center;
-}
-.ds-refresh {
-  display: inline-flex;
+.ds-actions {
+  display: flex;
+  gap: 12px;
   align-items: center;
-  gap: 6px;
-  width: 100%;
-  justify-content: center;
+  margin-top: 16px;
 }
-.ds-refresh .dashicons {
-  font-size: 16px;
-  width: 16px;
-  height: 16px;
-  line-height: 1;
+.ds-widget .ds-dismiss {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  cursor: pointer;
+  font: inherit;
+  color: var(--ds-accent);
+  text-decoration: underline;
 }
-.ds-refresh.is-loading .dashicons { animation: ds-spin 0.8s linear infinite; }
-@keyframes ds-spin { to { transform: rotate(360deg); } }
-.ds-pile-count {
-  margin: 8px 0 0;
-  color: var(--ds-text-soft);
-  font-size: 12px;
-  font-style: italic;
+.ds-widget .ds-dismiss:hover,
+.ds-widget .ds-dismiss:focus {
+  text-decoration: none;
+  background: transparent;
+  color: var(--ds-accent);
 }
 
 .ds-empty {
-  color: var(--ds-text-secondary);
-  padding: 20px 14px;
   margin: 0;
+  padding: 36px 22px;
   text-align: center;
+  font-family: Georgia, "Times New Roman", serif;
   font-style: italic;
+  font-size: 14px;
+  color: var(--ds-text-secondary);
 }
-
-.ds-item.is-dismissing { opacity: 0.4; transition: opacity 0.2s; }

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -1,8 +1,7 @@
 (function ($) {
   'use strict';
 
-  function refresh($widget, $button) {
-    if ($button) { $button.addClass('is-loading').prop('disabled', true); }
+  function refresh($widget) {
     return $.post(DraftSweeper.ajaxUrl, {
       action: 'draft_sweeper_refresh',
       nonce: DraftSweeper.nonce,
@@ -10,15 +9,8 @@
       if (resp && resp.success) {
         $widget.find('.inside').html(resp.data.html);
       }
-    }).always(function () {
-      if ($button) { $button.removeClass('is-loading').prop('disabled', false); }
     });
   }
-
-  $(document).on('click', '#draft_sweeper_widget .ds-refresh', function (e) {
-    e.preventDefault();
-    refresh($('#draft_sweeper_widget'), $(this));
-  });
 
   $(document).on('click', '#draft_sweeper_widget .ds-dismiss', function (e) {
     e.preventDefault();

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -5,16 +5,13 @@ namespace DraftSweeper\Dashboard;
 
 use DraftSweeper\Drafts\DraftSnapshot;
 use DraftSweeper\Plugin;
-use DraftSweeper\Scoring\Score;
 
 final class DashboardWidget
 {
     private const WIDGET_ID = 'draft_sweeper_widget';
     private const NONCE_ACTION = 'draft_sweeper_widget';
     private const DISMISSED_META = '_draft_sweeper_dismissed';
-    private const OFFSET_META = '_draft_sweeper_offset';
     private const DISMISS_TTL_DAYS = 14;
-    private const TOP_N = 3;
 
     public function __construct(private readonly Plugin $plugin)
     {
@@ -37,9 +34,10 @@ final class DashboardWidget
         if ($hook !== 'index.php') {
             return;
         }
-        $url = $this->plugin->pluginUrl();
-        wp_enqueue_style('draft-sweeper-widget', $url . 'assets/widget.css', ['dashicons'], '0.4.0');
-        wp_enqueue_script('draft-sweeper-widget', $url . 'assets/widget.js', ['jquery'], '0.4.0', true);
+        $url = plugin_dir_url($this->plugin->pluginFile());
+        $dir = plugin_dir_path($this->plugin->pluginFile());
+        wp_enqueue_style('draft-sweeper-widget', $url . 'assets/widget.css', [], (string) filemtime($dir . 'assets/widget.css'));
+        wp_enqueue_script('draft-sweeper-widget', $url . 'assets/widget.js', ['jquery'], (string) filemtime($dir . 'assets/widget.js'), true);
         wp_localize_script('draft-sweeper-widget', 'DraftSweeper', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'nonce'   => wp_create_nonce(self::NONCE_ACTION),
@@ -57,7 +55,6 @@ final class DashboardWidget
         if (! current_user_can('edit_posts')) {
             wp_send_json_error('forbidden', 403);
         }
-        $this->bumpOffset();
         wp_send_json_success(['html' => $this->renderShell()]);
     }
 
@@ -98,20 +95,12 @@ final class DashboardWidget
         return array_filter($dismissed, static fn($ts) => (int) $ts >= $cutoff);
     }
 
-    private function offset(): int
+    /**
+     * Stable day index in the site's timezone. Increments at site-local midnight.
+     */
+    private function dayIndex(): int
     {
-        $offset = (int) get_user_meta(get_current_user_id(), self::OFFSET_META, true);
-        return max(0, $offset);
-    }
-
-    private function bumpOffset(): void
-    {
-        update_user_meta(get_current_user_id(), self::OFFSET_META, $this->offset() + self::TOP_N);
-    }
-
-    private function resetOffset(): void
-    {
-        delete_user_meta(get_current_user_id(), self::OFFSET_META);
+        return ((int) wp_date('Y')) * 366 + ((int) wp_date('z'));
     }
 
     private function renderShell(): string
@@ -134,49 +123,15 @@ final class DashboardWidget
         }
         usort($scored, fn($a, $b) => $b['score']->total <=> $a['score']->total);
 
-        $total = count($scored);
-        $offset = $this->offset();
-        if ($offset >= $total) {
-            $this->resetOffset();
-            $offset = 0;
-        }
-        $window = array_slice($scored, $offset, self::TOP_N);
-        if ($window === []) {
-            $this->resetOffset();
-            $window = array_slice($scored, 0, self::TOP_N);
-        }
-        $hasMore = $total > self::TOP_N;
-
-        $highlight = new Highlight();
+        $todays = $scored[$this->dayIndex() % count($scored)];
         $summarizer = $this->plugin->summaryGenerator();
 
         ob_start();
         ?>
         <div class="ds-widget">
             <ul class="ds-list">
-                <?php foreach ($window as $row) {
-                    $this->renderItem($row['draft'], $row['score'], $highlight, $summarizer);
-                } ?>
+                <?php $this->renderItem($todays['draft'], $summarizer); ?>
             </ul>
-            <?php if ($hasMore) : ?>
-                <div class="ds-footer">
-                    <button type="button" class="button ds-refresh">
-                        <span class="dashicons dashicons-update-alt" aria-hidden="true"></span>
-                        <span class="ds-refresh-label"><?php esc_html_e('Show me more drafts', 'draft-sweeper'); ?></span>
-                    </button>
-                    <p class="ds-pile-count"><?php
-                        printf(
-                            esc_html(_n(
-                                'You have %s draft hiding in your pile.',
-                                'You have %s drafts hiding in your pile.',
-                                $total,
-                                'draft-sweeper'
-                            )),
-                            esc_html(number_format_i18n($total))
-                        );
-                    ?></p>
-                </div>
-            <?php endif; ?>
         </div>
         <?php
         return (string) ob_get_clean();
@@ -189,42 +144,56 @@ final class DashboardWidget
             . '</p></div>';
     }
 
-    private function renderItem(DraftSnapshot $draft, Score $score, Highlight $highlight, $summarizer): void
+    private function renderItem(DraftSnapshot $draft, $summarizer): void
     {
-        $reason = $highlight->reason($draft, $score);
         $teaser = $this->teaser($draft, $summarizer);
-        $started = $draft->evocativeStarted !== '' ? $draft->evocativeStarted : ('from ' . $draft->startedHuman . ' ago');
+        $prompt = sprintf(
+            /* translators: %s is a relative time phrase like "two weeks ago" or "in October". */
+            __('Pick up where you left off %s', 'draft-sweeper'),
+            $this->timePhrase($draft)
+        );
         ?>
         <li class="ds-item" data-id="<?php echo esc_attr((string) $draft->id); ?>">
-            <span class="ds-badge">
-                <?php echo esc_html($this->reasonLabel($reason)); ?>
-            </span>
+            <span class="ds-badge"><?php echo esc_html($prompt); ?></span>
             <?php if ($teaser !== '') : ?>
                 <p class="ds-teaser"><?php echo esc_html($teaser); ?></p>
             <?php endif; ?>
             <a class="ds-title" href="<?php echo esc_url($draft->editLink); ?>">
                 <?php echo wp_kses($this->displayTitle($draft), ['span' => ['class' => true]]); ?>
             </a>
-            <p class="ds-meta">
-                <span><?php echo esc_html(ucfirst($started)); ?></span>
-                <span class="ds-meta-sep" aria-hidden="true">·</span>
-                <span><?php
-                    printf(
-                        esc_html(_n('%s word', '%s words', $draft->wordCount, 'draft-sweeper')),
-                        esc_html(number_format_i18n($draft->wordCount))
-                    );
-                ?></span>
-            </p>
             <div class="ds-actions">
                 <a class="button button-primary button-small" href="<?php echo esc_url($draft->editLink); ?>">
                     <?php esc_html_e('Pick this up', 'draft-sweeper'); ?>
                 </a>
-                <button type="button" class="button button-small ds-dismiss">
-                    <?php esc_html_e('Save for later', 'draft-sweeper'); ?>
+                <button type="button" class="ds-dismiss">
+                    <?php esc_html_e('Not today', 'draft-sweeper'); ?>
                 </button>
             </div>
         </li>
         <?php
+    }
+
+    /**
+     * Adapts the EvocativeDate phrasing so it reads naturally after
+     * "Pick up where you left off ...". Most evocative phrases start with
+     * "from", which doesn't sit right after "left off".
+     */
+    private function timePhrase(DraftSnapshot $draft): string
+    {
+        if ($draft->evocativeStarted === '') {
+            return $draft->startedHuman . ' ago';
+        }
+        $phrase = $draft->evocativeStarted;
+        if (str_starts_with($phrase, 'from a ') && str_contains($phrase, ' in ')) {
+            return 'on a ' . substr($phrase, 7);
+        }
+        if (str_starts_with($phrase, 'from last ')) {
+            return substr($phrase, 5);
+        }
+        if (str_starts_with($phrase, 'from ')) {
+            return 'in ' . substr($phrase, 5);
+        }
+        return $phrase;
     }
 
     /**
@@ -237,17 +206,6 @@ final class DashboardWidget
             return $draft->openingSentence;
         }
         return $summarizer->summarize($draft);
-    }
-
-    private function reasonLabel(string $reason): string
-    {
-        return match ($reason) {
-            Highlight::REASON_ALMOST_DONE  => __('Nearly ready', 'draft-sweeper'),
-            Highlight::REASON_ON_TREND     => __('Timely again', 'draft-sweeper'),
-            Highlight::REASON_BURIED       => __('Buried treasure', 'draft-sweeper'),
-            Highlight::REASON_HALF_WRITTEN => __('A spark in progress', 'draft-sweeper'),
-            default                        => __('An idea waiting', 'draft-sweeper'),
-        };
     }
 
     private function displayTitle(DraftSnapshot $draft): string


### PR DESCRIPTION
## Summary

Rethinks the widget around a single daily pick instead of a top-3 list with manual paging, and refreshes the visual treatment.

**Behavior**
- One draft surfaced per day, picked by `dayIndex % count` against the score-sorted pool
- "Show me more drafts" button and the per-user offset machinery are gone — the only way to see a different draft is to dismiss today's via "Not today", which removes it from the pool for 14 days
- Pile-count line removed (the widget no longer surfaces anything beyond today's pick)

**Visual**
- Soft gray paper surface (`#f6f7f7`) covering the whole widget interior
- Reason badge replaced with a sans-serif, time-aware prompt: "Pick up where you left off in October" / "earlier this week" / "on a Tuesday in October" — `timePhrase()` adapts the existing `EvocativeDate` phrasing so it reads naturally after "left off"
- Word-count meta line dropped (date moved into the prompt)
- Buttons restored to WP design-system defaults; "Not today" rendered as a plain link

**Dev quality-of-life**
- Asset URLs use `plugin_dir_url()` (the previous `pluginUrl()` helper omitted the trailing slash, producing 404s in some envs)
- Both CSS and JS use `filemtime()` so iterations bust browser cache automatically

## Notes for review
- Reviewer Playground link will be auto-posted by the existing `playground-preview` workflow
- The `Highlight` class is no longer used by the widget but kept (it has its own tests and may be useful later)
- New translatable string: `Pick up where you left off %s`

## Test plan
- [ ] Widget renders one draft on the dashboard
- [ ] "Pick up where you left off …" reads naturally across time formats: very recent (`earlier this week`), within-month (`on a Tuesday in October`), older same-year (`in October`), prior year (`last fall` / `in October last year`), much older (`in October 2024`)
- [ ] "Pick this up" opens the editor for the right draft
- [ ] "Not today" dismisses the current draft; widget re-renders with a different one (or the empty state)
- [ ] Empty state ("Nothing hiding in your draft pile. Nice work.") still appears when no eligible drafts
- [ ] Settings page still works — no regressions there
