### PR TITLE
AI-driven selection so today's draft is more resonant

### DIFF
--- a/src/Ai/AiDailyPicker.php
+++ b/src/Ai/AiDailyPicker.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace DraftSweeper\Ai;
+
+use DraftSweeper\Dashboard\DailyPicker;
+use DraftSweeper\Drafts\DraftSnapshot;
+
+/**
+ * When an AI provider is configured, this picker hands the top deterministic
+ * candidates to the model and asks it to choose the single most resonant one
+ * for today, returning a short "why this one" nudge.
+ *
+ * Token-budget conscious: we send at most 3 candidates, each truncated to
+ * ~200 chars of excerpt, plus up to 5 recent topic terms for context. The
+ * AI response is constrained to a JSON object with two short fields.
+ *
+ * Falls back to deterministic top-1 when no provider is available, the
+ * AiClient class is missing, or the response can't be parsed.
+ *
+ * @phpstan-type Scored array{draft: DraftSnapshot, score: \DraftSweeper\Scoring\Score}
+ */
+final class AiDailyPicker
+{
+    private const MAX_CANDIDATES = 3;
+    private const EXCERPT_CHARS  = 200;
+    private const MAX_TOKENS     = 160;
+
+    public function __construct(
+        private readonly AiProviderResolver $resolver,
+        private readonly DailyPicker $deterministic,
+    ) {
+    }
+
+    /**
+     * @param list<Scored> $scored
+     * @param list<string> $recentTopicLabels  e.g. ['gardening', 'WordPress', 'travel']
+     * @return array{draft: DraftSnapshot, score: \DraftSweeper\Scoring\Score, nudge: string}|null
+     */
+    public function pick(array $scored, array $recentTopicLabels = []): ?array
+    {
+        $candidates = $this->deterministic->topN($scored, self::MAX_CANDIDATES);
+        if ($candidates === []) {
+            return null;
+        }
+
+        $provider = $this->resolver->resolve();
+        if ($provider === null || ! class_exists('\\WordPress\\AiClient\\AiClient') || count($candidates) === 1) {
+            $top = $candidates[0];
+            return ['draft' => $top['draft'], 'score' => $top['score'], 'nudge' => ''];
+        }
+
+        $prompt = $this->buildPrompt($candidates, $recentTopicLabels);
+
+        try {
+            $response = \WordPress\AiClient\AiClient::generateText([
+                'provider'   => $provider['id'],
+                'prompt'     => $prompt,
+                'max_tokens' => self::MAX_TOKENS,
+            ]);
+            $text = is_string($response) ? $response : (string) ($response['text'] ?? '');
+            $parsed = $this->parse($text);
+            if ($parsed === null) {
+                $top = $candidates[0];
+                return ['draft' => $top['draft'], 'score' => $top['score'], 'nudge' => ''];
+            }
+
+            foreach ($candidates as $row) {
+                if ($row['draft']->id === $parsed['post_id']) {
+                    return ['draft' => $row['draft'], 'score' => $row['score'], 'nudge' => $parsed['nudge']];
+                }
+            }
+        } catch (\Throwable) {
+            // fall through
+        }
+
+        $top = $candidates[0];
+        return ['draft' => $top['draft'], 'score' => $top['score'], 'nudge' => ''];
+    }
+
+    /**
+     * @param list<Scored> $candidates
+     * @param list<string> $topics
+     */
+    private function buildPrompt(array $candidates, array $topics): string
+    {
+        $lines = [];
+        foreach ($candidates as $row) {
+            $d = $row['draft'];
+            $excerpt = $this->trimExcerpt($d->excerpt !== '' ? $d->excerpt : $d->openingSentence);
+            $title = $d->hasTitle ? $d->title : '(untitled)';
+            $lines[] = sprintf('- id=%d | %d words | %s | %s', $d->id, $d->wordCount, $title, $excerpt);
+        }
+        $candidateBlock = implode("\n", $lines);
+        $topicBlock = $topics === []
+            ? '(none)'
+            : implode(', ', array_slice($topics, 0, 5));
+
+        return <<<PROMPT
+Pick the ONE draft from the list below that the writer would most want to return to today, given the recent topics on their site. Reply with JSON only, no preamble: {"id": <int>, "nudge": "<one short sentence, max 18 words, evocative, no productivity language>"}.
+
+Recent site topics: {$topicBlock}
+
+Drafts:
+{$candidateBlock}
+PROMPT;
+    }
+
+    private function trimExcerpt(string $text): string
+    {
+        $text = trim((string) preg_replace('/\s+/', ' ', $text));
+        if ($text === '') {
+            return '(no excerpt)';
+        }
+        if (function_exists('mb_strimwidth')) {
+            return mb_strimwidth($text, 0, self::EXCERPT_CHARS, '…');
+        }
+        return strlen($text) > self::EXCERPT_CHARS ? substr($text, 0, self::EXCERPT_CHARS - 1) . '…' : $text;
+    }
+
+    /** @return array{post_id:int,nudge:string}|null */
+    private function parse(string $text): ?array
+    {
+        $text = trim($text);
+        if ($text === '') {
+            return null;
+        }
+        // Extract first {...} block in case the model wraps it in prose.
+        if (preg_match('/\{.*\}/s', $text, $m)) {
+            $text = $m[0];
+        }
+        $data = json_decode($text, true);
+        if (! is_array($data)) {
+            return null;
+        }
+        $id = isset($data['id']) ? (int) $data['id'] : 0;
+        $nudge = isset($data['nudge']) ? trim((string) $data['nudge']) : '';
+        if ($id <= 0) {
+            return null;
+        }
+        return ['post_id' => $id, 'nudge' => $nudge];
+    }
+}

--- a/src/Dashboard/DailyPicker.php
+++ b/src/Dashboard/DailyPicker.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace DraftSweeper\Dashboard;
+
+use DraftSweeper\Drafts\DraftSnapshot;
+use DraftSweeper\Scoring\Score;
+
+/**
+ * Pure helper that picks today's single draft from a scored list.
+ * Sort order = highest total score first; ties keep input order.
+ *
+ * Inputs are already filtered (no dismissed drafts), so the picker
+ * just orders and returns the top one — or null if the list is empty.
+ *
+ * @phpstan-type Scored array{draft: DraftSnapshot, score: Score}
+ */
+final class DailyPicker
+{
+    /**
+     * @param list<Scored> $scored
+     * @return Scored|null
+     */
+    public function pick(array $scored): ?array
+    {
+        if ($scored === []) {
+            return null;
+        }
+        usort($scored, static fn($a, $b) => $b['score']->total <=> $a['score']->total);
+        return $scored[0];
+    }
+
+    /**
+     * Returns the top N candidates (by score) for handoff to the AI picker.
+     *
+     * @param list<Scored> $scored
+     * @param int $n
+     * @return list<Scored>
+     */
+    public function topN(array $scored, int $n): array
+    {
+        usort($scored, static fn($a, $b) => $b['score']->total <=> $a['score']->total);
+        return array_slice($scored, 0, max(1, $n));
+    }
+}

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -121,20 +121,56 @@ final class DashboardWidget
         foreach ($available as $draft) {
             $scored[] = ['draft' => $draft, 'score' => $calc->calculate($draft, $topics)];
         }
-        usort($scored, fn($a, $b) => $b['score']->total <=> $a['score']->total);
 
-        $todays = $scored[$this->dayIndex() % count($scored)];
+        $nudge = '';
+        $aiPicker = $this->plugin->aiDailyPicker();
+        if ($aiPicker !== null) {
+            $picked = $aiPicker->pick($scored, $this->topicLabels($topics));
+            if ($picked !== null) {
+                $todays = ['draft' => $picked['draft'], 'score' => $picked['score']];
+                $nudge = $picked['nudge'];
+            } else {
+                $todays = null;
+            }
+        } else {
+            $todays = $this->plugin->dailyPicker()->pick($scored);
+        }
+
+        if ($todays === null) {
+            return $this->renderEmpty();
+        }
+
         $summarizer = $this->plugin->summaryGenerator();
 
         ob_start();
         ?>
         <div class="ds-widget">
             <ul class="ds-list">
-                <?php $this->renderItem($todays['draft'], $summarizer); ?>
+                <?php $this->renderItem($todays['draft'], $summarizer, $nudge); ?>
             </ul>
         </div>
         <?php
         return (string) ob_get_clean();
+    }
+
+    /**
+     * @param array<int, int> $topics term ID => frequency
+     * @return list<string>
+     */
+    private function topicLabels(array $topics): array
+    {
+        if ($topics === []) {
+            return [];
+        }
+        arsort($topics);
+        $labels = [];
+        foreach (array_slice(array_keys($topics), 0, 5, true) as $termId) {
+            $term = function_exists('get_term') ? get_term((int) $termId) : null;
+            if ($term && ! is_wp_error($term) && isset($term->name) && $term->name !== '') {
+                $labels[] = (string) $term->name;
+            }
+        }
+        return $labels;
     }
 
     private function renderEmpty(): string
@@ -144,9 +180,9 @@ final class DashboardWidget
             . '</p></div>';
     }
 
-    private function renderItem(DraftSnapshot $draft, $summarizer): void
+    private function renderItem(DraftSnapshot $draft, $summarizer, string $nudge = ''): void
     {
-        $teaser = $this->teaser($draft, $summarizer);
+        $teaser = $nudge !== '' ? $nudge : $this->teaser($draft, $summarizer);
         $prompt = sprintf(
             /* translators: %s is a relative time phrase like "two weeks ago" or "in October". */
             __('Pick up where you left off %s', 'draft-sweeper'),
@@ -156,7 +192,7 @@ final class DashboardWidget
         <li class="ds-item" data-id="<?php echo esc_attr((string) $draft->id); ?>">
             <span class="ds-badge"><?php echo esc_html($prompt); ?></span>
             <?php if ($teaser !== '') : ?>
-                <p class="ds-teaser"><?php echo esc_html($teaser); ?></p>
+                <p class="ds-teaser<?php echo $nudge !== '' ? ' ds-teaser-ai' : ''; ?>"><?php echo esc_html($teaser); ?></p>
             <?php endif; ?>
             <a class="ds-title" href="<?php echo esc_url($draft->editLink); ?>">
                 <?php echo wp_kses($this->displayTitle($draft), ['span' => ['class' => true]]); ?>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace DraftSweeper;
 
+use DraftSweeper\Ai\AiDailyPicker;
 use DraftSweeper\Ai\AiProviderResolver;
 use DraftSweeper\Ai\AiSummaryGenerator;
 use DraftSweeper\Ai\ExcerptSummaryGenerator;
 use DraftSweeper\Ai\SummaryGenerator;
 use DraftSweeper\Cli\SweepCommand;
+use DraftSweeper\Dashboard\DailyPicker;
 use DraftSweeper\Dashboard\DashboardWidget;
 use DraftSweeper\Drafts\DraftRepository;
 use DraftSweeper\Drafts\RecentTopicsProvider;
@@ -95,6 +97,19 @@ final class Plugin
             return $fallback;
         }
         return new AiSummaryGenerator(new AiProviderResolver(), $fallback);
+    }
+
+    public function dailyPicker(): DailyPicker
+    {
+        return new DailyPicker();
+    }
+
+    public function aiDailyPicker(): ?AiDailyPicker
+    {
+        if (! $this->settings()['enable_ai']) {
+            return null;
+        }
+        return new AiDailyPicker(new AiProviderResolver(), $this->dailyPicker());
     }
 
     private function registerHooks(): void

--- a/tests/Dashboard/DailyPickerTest.php
+++ b/tests/Dashboard/DailyPickerTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace DraftSweeper\Tests\Dashboard;
+
+use DraftSweeper\Dashboard\DailyPicker;
+use DraftSweeper\Drafts\DraftSnapshot;
+use DraftSweeper\Scoring\Score;
+use DraftSweeper\Scoring\Weights;
+use PHPUnit\Framework\TestCase;
+
+final class DailyPickerTest extends TestCase
+{
+    /** @return array{draft: DraftSnapshot, score: Score} */
+    private function row(int $id, float $completeness, float $recency, float $relevance): array
+    {
+        $draft = new DraftSnapshot($id, "Title $id", '', 500, true, false, false, 0, 0, [], 10, 'x', 'x', 'x', '', '');
+        $score = new Score($completeness, $recency, $relevance, new Weights());
+        return ['draft' => $draft, 'score' => $score];
+    }
+
+    public function test_pick_returns_null_when_empty(): void
+    {
+        $this->assertNull((new DailyPicker())->pick([]));
+    }
+
+    public function test_pick_returns_highest_total_score(): void
+    {
+        $rows = [
+            $this->row(1, 0.2, 0.5, 0.1),
+            $this->row(2, 0.9, 0.5, 0.5),
+            $this->row(3, 0.4, 0.4, 0.4),
+        ];
+        $picked = (new DailyPicker())->pick($rows);
+        $this->assertNotNull($picked);
+        $this->assertSame(2, $picked['draft']->id);
+    }
+
+    public function test_top_n_orders_and_caps(): void
+    {
+        $rows = [
+            $this->row(1, 0.2, 0.5, 0.1),
+            $this->row(2, 0.9, 0.5, 0.5),
+            $this->row(3, 0.4, 0.4, 0.4),
+            $this->row(4, 0.7, 0.7, 0.7),
+        ];
+        $top = (new DailyPicker())->topN($rows, 2);
+        $this->assertCount(2, $top);
+        $this->assertSame(2, $top[0]['draft']->id);
+        $this->assertSame(4, $top[1]['draft']->id);
+    }
+
+    public function test_top_n_floor_is_one_for_zero_request(): void
+    {
+        $rows = [$this->row(1, 0.5, 0.5, 0.5)];
+        $this->assertCount(1, (new DailyPicker())->topN($rows, 0));
+    }
+}


### PR DESCRIPTION
Extracted from #6 — pure selection/relevancy improvement, no daily-rollover or save-for-later UX.

## Summary
- The widget already shows a single draft per day; this PR upgrades **how** that draft is chosen.
- Without AI: deterministic top-1 by existing score (completeness / recency / relevance).
- With AI: top 3 deterministic candidates + up to 5 recent topic terms go to the configured Connectors API provider, which picks the most resonant draft for *today* and returns a short one-sentence nudge. Falls back to deterministic top-1 on any failure.

## Architecture
- `Dashboard/DailyPicker` — pure helper, ranks scored candidates and returns top-1 / top-N.
- `Ai/AiDailyPicker` — wraps the deterministic picker with an AI selection step using `\WordPress\AiClient\AiClient`. JSON-only response, defensive parsing, graceful fallback.
- `Plugin::aiDailyPicker()` returns null when `enable_ai` is off, so the no-AI path costs nothing.
- `DashboardWidget::renderShell()` swaps the previous `dayIndex() % count` rotation for picker output. The AI nudge (when present) replaces the opening-sentence teaser, surfaced with a `.ds-teaser-ai` class hook for styling.

## Token budget
Per the [Connectors API guidance](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/), the prompt is intentionally compact:
- 3 candidates max
- excerpts truncated to ~200 chars
- 5 topic terms max
- 160 max output tokens, JSON-only response

## Test plan
- [x] `vendor/bin/phpunit` — 39 passing (4 new in `DailyPickerTest`).
- [x] `php -l` clean across changed files.
- [ ] Manual: `wp-now` with seeded drafts — confirm a draft renders and the teaser changes if a Connectors provider is configured.
- [ ] Manual: configure an AI connector (e.g. `ANTHROPIC_API_KEY`), verify the AI nudge replaces the opening-sentence teaser; remove the key and confirm the teaser falls back.

## Out of scope (still in #6)
- `DailyPickStore` (persist today's pick + rollover at local midnight)
- "Save for later" → one re-pick → "see you tomorrow" flow
- Hero-card visual redesign / CSS / JS

🤖 Generated with [Craft Agent](https://craft.do) (powered by [Claude Code](https://claude.com/claude-code))