### PR TITLE
Exclude Future Drafts entries from the widget

### DIFF
--- a/src/Drafts/DraftRepository.php
+++ b/src/Drafts/DraftRepository.php
@@ -11,9 +11,9 @@ final class DraftRepository
     }
 
     /**
-     * @return DraftSnapshot[]
+     * @return array<string, mixed>
      */
-    public function recent(?int $userId = null): array
+    public function buildQueryArgs(?int $userId = null): array
     {
         $args = [
             'post_type'      => 'post',
@@ -22,12 +22,30 @@ final class DraftRepository
             'order'          => 'DESC',
             'posts_per_page' => $this->limit,
             'no_found_rows'  => true,
+            // Exclude drafts that companion plugins have marked as
+            // intentionally time-delayed (e.g. Future Drafts'
+            // `_future_draft_remind_on`). Such drafts aren't abandoned —
+            // they're scheduled to resurface elsewhere.
+            'meta_query'     => [
+                [
+                    'key'     => '_future_draft_remind_on',
+                    'compare' => 'NOT EXISTS',
+                ],
+            ],
         ];
         if ($userId !== null) {
             $args['author'] = $userId;
         }
 
-        $query = new \WP_Query($args);
+        return $args;
+    }
+
+    /**
+     * @return DraftSnapshot[]
+     */
+    public function recent(?int $userId = null): array
+    {
+        $query = new \WP_Query($this->buildQueryArgs($userId));
         $now = time();
         $evocative = new EvocativeDate($now);
         $opener = new OpeningSentence();

--- a/tests/Drafts/DraftRepositoryTest.php
+++ b/tests/Drafts/DraftRepositoryTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace DraftSweeper\Tests\Drafts;
+
+use DraftSweeper\Drafts\DraftRepository;
+use PHPUnit\Framework\TestCase;
+
+final class DraftRepositoryTest extends TestCase
+{
+    public function test_query_args_exclude_drafts_with_future_drafts_meta(): void
+    {
+        $repo = new DraftRepository();
+        $args = $repo->buildQueryArgs();
+
+        $this->assertArrayHasKey('meta_query', $args);
+        $this->assertSame(
+            [
+                [
+                    'key'     => '_future_draft_remind_on',
+                    'compare' => 'NOT EXISTS',
+                ],
+            ],
+            $args['meta_query'],
+        );
+    }
+
+    public function test_query_args_keep_core_draft_filters(): void
+    {
+        // Drafts without the Future Drafts meta still match the underlying
+        // post_status='draft' filter — the meta_query only narrows the set.
+        $args = (new DraftRepository(25))->buildQueryArgs(7);
+
+        $this->assertSame('post', $args['post_type']);
+        $this->assertSame('draft', $args['post_status']);
+        $this->assertSame(25, $args['posts_per_page']);
+        $this->assertSame(7, $args['author']);
+    }
+
+    public function test_query_args_omit_author_when_user_id_not_given(): void
+    {
+        $args = (new DraftRepository())->buildQueryArgs();
+
+        $this->assertArrayNotHasKey('author', $args);
+    }
+}


### PR DESCRIPTION
Closes #7.

## Summary
- Filter `WP_Query` in `DraftRepository` with a `meta_query` that excludes drafts carrying `_future_draft_remind_on` — the meta key set by the Future Drafts companion plugin to mark intentionally time-delayed drafts.
- Extract `buildQueryArgs()` so the query shape is unit-testable without booting WordPress.
- Add `DraftRepositoryTest` covering the new exclusion plus existing filters/author behavior.

Skipped the optional `draft_sweeper_query_args` filter — happy to add it in a follow-up if a second companion plugin needs the same hook.

## Test plan
- [x] `vendor/bin/phpunit` — 38 tests pass
- [ ] Manual: install Future Drafts alongside Draft Sweeper, confirm a draft with `_future_draft_remind_on` is hidden from the widget while a normal draft still appears