### PR TITLE
Flip .ds-dismiss link hover

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -62,11 +62,11 @@
   cursor: pointer;
   font: inherit;
   color: var(--ds-accent);
-  text-decoration: underline;
+  text-decoration: none;
 }
 .ds-widget .ds-dismiss:hover,
 .ds-widget .ds-dismiss:focus {
-  text-decoration: none;
+  text-decoration: underline;
   background: transparent;
   color: var(--ds-accent);
 }


### PR DESCRIPTION
## Summary

Swaps the default and hover states for the "Not today" link button:

- **Before:** underlined by default, underline drops on hover
- **After:** no underline by default, underline appears on hover/focus

Mirrors how the rest of the admin chrome treats text links — most secondary actions in WP admin reveal the underline on hover rather than carrying it by default. Reads less busy on first paint.

## Test plan

- [ ] Hover over "Not today" — underline appears, color stays accent
- [ ] Move mouse away — underline drops, color stays accent
- [ ] Tab to focus — same as hover (underline + accent color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)