### PR TITLE
Match Pick this up to other widgets' primary buttons

### DIFF
--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.0
+ * Version:           0.5.1
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -303,7 +303,7 @@ final class DashboardWidget
                 <?php echo wp_kses($this->displayTitle($draft), ['span' => ['class' => true]]); ?>
             </a>
             <div class="ds-actions">
-                <a class="button button-primary button-small" href="<?php echo esc_url($draft->editLink); ?>">
+                <a class="button button-primary" href="<?php echo esc_url($draft->editLink); ?>">
                     <?php esc_html_e('Pick this up', 'draft-sweeper'); ?>
                 </a>
                 <button type="button" class="ds-dismiss">


### PR DESCRIPTION
## Summary
- Drop `.button-small` from the "Pick this up" CTA so it sizes the same as Ideas Inbox's "Add idea" and Habit Creator's "Create a post"
- Bump version to 0.5.1 to bust the plugin asset cache

The small variant was making the Draft Sweeper card feel visually lighter than its peer widgets in the dashboard column.

## Test plan
- [ ] Open WP dashboard, confirm the "Pick this up" button now matches the height/padding of "Add idea" (Ideas Inbox) and "Save Draft" (core activity widget)
- [ ] "Not today" still vertically centers next to the larger CTA
- [ ] Visual check passes in Modern, Coffee, and Ocean admin color schemes