### PR TITLE
Simplify untitled draft fallback to "Untitled post"

### DIFF
--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.1
+ * Version:           0.5.2
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -355,13 +355,6 @@ final class DashboardWidget
             return esc_html($draft->title);
         }
 
-        $excerpt = trim($draft->excerpt);
-        $snippet = $excerpt !== '' ? mb_strimwidth($excerpt, 0, 50, '…') : '';
-
-        $label = '<span class="ds-untitled">' . esc_html__('Untitled', 'draft-sweeper') . '</span>';
-        if ($snippet !== '') {
-            $label .= ' · ' . esc_html($snippet);
-        }
-        return $label;
+        return '<span class="ds-untitled">' . esc_html__('Untitled post', 'draft-sweeper') . '</span>';
     }
 }


### PR DESCRIPTION
## Summary
- When a draft has no title, the title slot now reads just *Untitled post* in italic — dropping the previous `Untitled · <50-char snippet>` treatment
- The teaser line directly above already shows the draft's opening sentence, so the snippet was a near-duplicate that made the card feel dense

## Test plan
- [ ] Untitled draft renders *Untitled post* without separator or snippet
- [ ] Titled drafts still render their real title unchanged
