### PR TITLE
Round widget bottom corners to match the postbox

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -11,6 +11,13 @@
   font-size: 13px;
   line-height: 1.5;
   background: var(--ds-paper);
+  /* #dashboard-widgets .postbox has border-radius: 8px and a 1px
+     border, so the inner content edge curves with a 7px radius.
+     Match it on the bottom corners so the gray bg doesn't square off
+     the postbox's rounded corners. overflow: hidden clips any inner
+     content (last .ds-item, etc.) to the same curve. */
+  border-radius: 0 0 7px 7px;
+  overflow: hidden;
 }
 
 .ds-list { margin: 0; padding: 0; list-style: none; }

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.2
+ * Version:           0.5.3
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu


### PR DESCRIPTION
## Summary
Same fix as [annezazu/future-drafts#8](https://github.com/annezazu/future-drafts/pull/8). The dashboard postbox has `border-radius: 8px` and a 1px border (`#dashboard-widgets .postbox` in core `dashboard.css`), so the inner content edge curves with a 7px radius. `.ds-widget` fills `.inside` (which is `padding: 0`) with the gray `--ds-paper` background, so its sharp bottom corners were squaring off the postbox's rounded corners.

- Add `border-radius: 0 0 7px 7px` to `.ds-widget` so the gray curves with the postbox at the bottom.
- `overflow: hidden` clips the inner content (last `.ds-item`, etc.) to the same shape.
- Bumps plugin version 0.5.2 → 0.5.3.

## Test plan
- [ ] Load the dashboard; the bottom-left and bottom-right corners of the Draft Sweeper widget show the rounded `.postbox` border cleanly instead of being squared off by the gray fill.
- [ ] No visible clipping at the top corners (they sit below `.postbox-header` so the radius doesn't matter there).
- [ ] Top of the widget still butts up against the header band as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
