### PR TITLE
Float "Use AI" toggle top-right with hover/focus tooltip

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -7,6 +7,7 @@
   --ds-text-soft: #787c82;
   --ds-paper: #f6f7f7;
   --ds-accent: var(--wp-admin-theme-color, #2271b1);
+  position: relative;
   color: var(--ds-text);
   font-size: 13px;
   line-height: 1.5;
@@ -30,6 +31,8 @@
 
 .ds-badge {
   display: block;
+  /* Right-padding leaves room for the absolute top-right "Use AI" toggle. */
+  padding-right: 100px;
   margin-bottom: 14px;
   font-size: 13px;
   color: var(--ds-text-secondary);
@@ -79,19 +82,20 @@
 }
 
 /*
- * "Enhance with AI" toggle — visual replica of @wordpress/components
- * ToggleControl. Same markup/classes pattern as the Habit Creator and
- * Jot widgets so the three feel like one feature across plugins.
+ * "Use AI" toggle — minimal chrome floated top-right of the widget body.
+ * Visual replica of @wordpress/components ToggleControl. Same markup
+ * pattern as Habit Creator and Jot so the three feel like one feature
+ * across plugins.
  */
 .ds-ai-toggle {
+  position: absolute;
+  top: 14px;
+  right: 22px;
+  z-index: 1;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 4px 8px;
+  gap: 8px;
   margin: 0;
-  padding: 14px 22px;
-  border-bottom: 1px solid #e5e5e5;
-  background: #fff;
 }
 
 .ds-ai-toggle__form-toggle {
@@ -193,17 +197,40 @@
 }
 
 .ds-ai-toggle__label {
-  font-size: 13px;
-  color: var(--ds-text);
+  font-size: 12px;
+  color: var(--ds-text-soft);
   cursor: pointer;
   user-select: none;
 }
 
-.ds-ai-toggle__caption {
-  flex: 1 0 100%;
-  margin-left: 44px;
+/*
+ * Tooltip — visually hidden until the label is hovered or the toggle
+ * receives keyboard focus. Sits just below the toggle, anchored to its
+ * right edge so it doesn't overflow the widget on narrow viewports.
+ */
+.ds-ai-toggle__tooltip {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 2;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: #1d2327;
+  color: #fff;
   font-size: 12px;
-  color: var(--ds-text-soft);
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.ds-ai-toggle:hover .ds-ai-toggle__tooltip,
+.ds-ai-toggle__form-toggle:focus-visible ~ .ds-ai-toggle__tooltip,
+.ds-ai-toggle__label:focus-visible ~ .ds-ai-toggle__tooltip {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .ds-empty {

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -93,6 +93,7 @@
   right: 22px;
   z-index: 1;
   display: flex;
+  flex-direction: row-reverse;
   align-items: center;
   gap: 8px;
   margin: 0;

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -90,7 +90,7 @@
 .ds-ai-toggle {
   position: absolute;
   top: 14px;
-  right: 22px;
+  right: 14px;
   z-index: 1;
   display: flex;
   flex-direction: row-reverse;

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -20,9 +20,14 @@
     if (! $btn.length) return;
 
     var next = $btn.attr('aria-checked') !== 'true';
+    var $wrap = $btn.closest('.ds-ai-toggle');
+    var $tooltip = $wrap.find('.ds-ai-toggle__tooltip');
     var $body = $btn.closest('.ds-widget').find('.ds-body-wrap');
 
     $btn.toggleClass('is-checked', next).attr('aria-checked', next ? 'true' : 'false').addClass('is-saving');
+    if ($tooltip.length) {
+      $tooltip.text(next ? $tooltip.data('on') : $tooltip.data('off'));
+    }
 
     $.post(DraftSweeper.ajaxUrl, {
       action: 'draft_sweeper_toggle_ai',
@@ -35,8 +40,14 @@
         return;
       }
       $btn.toggleClass('is-checked', !next).attr('aria-checked', next ? 'false' : 'true');
+      if ($tooltip.length) {
+        $tooltip.text(next ? $tooltip.data('off') : $tooltip.data('on'));
+      }
     }).fail(function () {
       $btn.removeClass('is-saving').toggleClass('is-checked', !next).attr('aria-checked', next ? 'false' : 'true');
+      if ($tooltip.length) {
+        $tooltip.text(next ? $tooltip.data('off') : $tooltip.data('on'));
+      }
     });
   });
 

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -20,14 +20,9 @@
     if (! $btn.length) return;
 
     var next = $btn.attr('aria-checked') !== 'true';
-    var $wrap = $btn.closest('.ds-ai-toggle');
-    var $caption = $wrap.find('.ds-ai-toggle__caption');
     var $body = $btn.closest('.ds-widget').find('.ds-body-wrap');
 
     $btn.toggleClass('is-checked', next).attr('aria-checked', next ? 'true' : 'false').addClass('is-saving');
-    if ($caption.length) {
-      $caption.text(next ? $caption.data('on') : $caption.data('off'));
-    }
 
     $.post(DraftSweeper.ajaxUrl, {
       action: 'draft_sweeper_toggle_ai',
@@ -39,16 +34,9 @@
         $body.html(resp.data.html);
         return;
       }
-      // Revert if persistence failed.
       $btn.toggleClass('is-checked', !next).attr('aria-checked', next ? 'false' : 'true');
-      if ($caption.length) {
-        $caption.text(next ? $caption.data('off') : $caption.data('on'));
-      }
     }).fail(function () {
       $btn.removeClass('is-saving').toggleClass('is-checked', !next).attr('aria-checked', next ? 'false' : 'true');
-      if ($caption.length) {
-        $caption.text(next ? $caption.data('off') : $caption.data('on'));
-      }
     });
   });
 

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.8
+ * Version:           0.5.9
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.5
+ * Version:           0.5.6
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.3
+ * Version:           0.5.4
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.7
+ * Version:           0.5.8
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.6
+ * Version:           0.5.7
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/draft-sweeper.php
+++ b/draft-sweeper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Draft Sweeper
  * Plugin URI:        https://github.com/annezazu/draft-sweeper
  * Description:       Resurfaces abandoned drafts intelligently in the dashboard, with optional AI-generated nudges via the WordPress 7.0 Connectors API.
- * Version:           0.5.4
+ * Version:           0.5.5
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            annezazu

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -251,7 +251,7 @@ final class DashboardWidget
             <label
                 id="ds-ai-toggle-label"
                 class="ds-ai-toggle__label"
-            ><?php esc_html_e('Use AI', 'draft-sweeper'); ?></label>
+            ><?php esc_html_e('Uses AI', 'draft-sweeper'); ?></label>
             <span
                 id="ds-ai-toggle-help"
                 class="ds-ai-toggle__tooltip"

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -242,6 +242,7 @@ final class DashboardWidget
                 role="switch"
                 aria-checked="<?php echo $on ? 'true' : 'false'; ?>"
                 aria-labelledby="ds-ai-toggle-label"
+                aria-describedby="ds-ai-toggle-help"
             >
                 <span class="components-form-toggle__track" aria-hidden="true"></span>
                 <span class="components-form-toggle__thumb" aria-hidden="true"></span>
@@ -250,18 +251,12 @@ final class DashboardWidget
             <label
                 id="ds-ai-toggle-label"
                 class="ds-ai-toggle__label"
-            ><?php esc_html_e('Enhance with AI', 'draft-sweeper'); ?></label>
+            ><?php esc_html_e('Use AI', 'draft-sweeper'); ?></label>
             <span
-                class="ds-ai-toggle__caption"
-                data-on="<?php esc_attr_e('Drafts are summarized by AI.', 'draft-sweeper'); ?>"
-                data-off="<?php esc_attr_e('AI is off — heuristic summary.', 'draft-sweeper'); ?>"
-            ><?php
-                echo esc_html(
-                    $on
-                        ? __('Drafts are summarized by AI.', 'draft-sweeper')
-                        : __('AI is off — heuristic summary.', 'draft-sweeper')
-                );
-            ?></span>
+                id="ds-ai-toggle-help"
+                class="ds-ai-toggle__tooltip"
+                role="tooltip"
+            ><?php esc_html_e('Drafts are summarized by AI', 'draft-sweeper'); ?></span>
         </div>
         <?php
     }

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -256,7 +256,15 @@ final class DashboardWidget
                 id="ds-ai-toggle-help"
                 class="ds-ai-toggle__tooltip"
                 role="tooltip"
-            ><?php esc_html_e('Drafts are summarized by AI', 'draft-sweeper'); ?></span>
+                data-on="<?php esc_attr_e('Drafts are summarized by AI', 'draft-sweeper'); ?>"
+                data-off="<?php esc_attr_e('Drafts use a basic summary', 'draft-sweeper'); ?>"
+            ><?php
+                echo esc_html(
+                    $on
+                        ? __('Drafts are summarized by AI', 'draft-sweeper')
+                        : __('Drafts use a basic summary', 'draft-sweeper')
+                );
+            ?></span>
         </div>
         <?php
     }

--- a/src/Dashboard/DashboardWidget.php
+++ b/src/Dashboard/DashboardWidget.php
@@ -256,13 +256,13 @@ final class DashboardWidget
                 id="ds-ai-toggle-help"
                 class="ds-ai-toggle__tooltip"
                 role="tooltip"
-                data-on="<?php esc_attr_e('Drafts are summarized by AI', 'draft-sweeper'); ?>"
-                data-off="<?php esc_attr_e('Drafts use a basic summary', 'draft-sweeper'); ?>"
+                data-on="<?php esc_attr_e('AI picks today\'s draft and writes a nudge.', 'draft-sweeper'); ?>"
+                data-off="<?php esc_attr_e('Draft shows first few words.', 'draft-sweeper'); ?>"
             ><?php
                 echo esc_html(
                     $on
-                        ? __('Drafts are summarized by AI', 'draft-sweeper')
-                        : __('Drafts use a basic summary', 'draft-sweeper')
+                        ? __('AI picks today\'s draft and writes a nudge.', 'draft-sweeper')
+                        : __('Draft shows first few words.', 'draft-sweeper')
                 );
             ?></span>
         </div>


### PR DESCRIPTION
## Summary
- Frees a full row of widget chrome by floating the toggle in the widget's top-right corner instead of giving it a dedicated header row
- Label shortened from "Enhance with AI" to "Use AI"
- Helper text ("Drafts are summarized by AI") moves into a tooltip on the label/toggle, revealed on hover or keyboard focus
- Tooltip is static — the track itself communicates on/off, so the description just says what the feature does
- Drops the data-on/data-off caption swap from widget.js along with the inline caption span

## Accessibility
- Toggle button gets `aria-describedby` pointing at the tooltip span, so screen readers announce the description on focus regardless of whether the visual tooltip is rendered
- Tooltip reveals on `:focus-visible` of the toggle button **and** on label hover — keyboard and pointer users both see it

## Test plan
- [ ] Toggle renders top-right of the widget, not in a full-width row
- [ ] Hovering "Use AI" reveals the dark tooltip "Drafts are summarized by AI" below the toggle
- [ ] Keyboard-focusing the toggle (Tab to it) also reveals the tooltip
- [ ] Clicking the toggle still flips and persists the setting, and the widget body re-renders below
- [ ] First content row ("Pick up where you left off…") doesn't visually collide with the toggle
- [ ] Bottom rounded corners on the widget still match the postbox
